### PR TITLE
docs: sync plugin docs to code + add agent guide (UE 5.7)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,34 +1,12 @@
-# Codex Agent Guidelines
+# Agent Guidelines — GameplayFramework
 
-This repository contains the **GameplayFramework** plugin for Unreal Engine 5.5.
-The plugin provides a data-driven Gameplay Ability System and various utility
-classes (inventory, AI, UI widgets, etc.).  The repository does not contain
-automated tests.
+This repository is the **GameplayFramework** plugin for **Unreal Engine 5.7**: a data-driven, replicated Gameplay Ability System (GAS) framework with two Runtime modules (`GameplayFramework`, `Collectibles`) and no editor module. There is no automated test suite.
 
-Refer to `README.md` for detailed setup instructions on integrating the plugin
-into your Unreal project.
+**Canonical guide: see [`CLAUDE.md`](./CLAUDE.md).** It is the authoritative agent/contributor reference — module map, conventions, the shared-symlink gotcha, the FastArray inventory, build steps, and what does not exist. This file is only a pointer; do not duplicate that content here.
 
-## Repository Structure
+For human-facing setup and integration instructions, see [`README.md`](./README.md).
 
-- `GameplayFramework.uplugin` – plugin descriptor enabling required modules.
-- `Source/GameplayFramework/`
-  - `Public/` – header files. Subdirectories include:
-    - `AbilitySystem/` – gameplay abilities, attribute sets, effects,
-      modifiers and ability tasks.
-    - `AI/` – AI characters, controllers, and behaviour tree helpers.
-    - `Inventory/` – inventory components, item base classes, and factories.
-    - `UI/` – common UI widgets and widget controller classes.
-    - Additional headers for characters, game modes, projectiles and more.
-  - `Private/` – implementations mirroring the public layout.
-- `Content/` – example assets used by the plugin.
-- `Resources/` – plugin icon resources.
+Two things to internalize before editing:
 
-## Development Notes
-
-1. Add the plugin to the `Plugins/` folder of an Unreal 5.5 C++ project
-   (clone directly or as a git submodule).
-2. Run Unreal's `GenerateProjectFiles` script so the new module is detected.
-3. Build your project from your IDE or the Unreal Editor. The plugin will be
-   compiled along with the rest of the project.
-
-No automated test suite is provided.
+- This plugin is a **shared symlink**, not a git submodule. It is its own repo and is symlinked into each consumer's `Plugins/GameplayFramework`; editing it affects every consumer. Commit plugin changes from `C:/Source/GameplayFramework` directly.
+- Engine is **UE 5.7**; inventory is the new `FFastArraySerializer` system (the old UObject inventory was deleted); there is no `GameplayFrameworkEditor` module. See `CLAUDE.md` for details.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,77 @@
+# CLAUDE.md — GameplayFramework plugin (canonical agent guide)
+
+This is the canonical guide for AI agents and contributors working in this repository. `AGENTS.md` is a short pointer to this file; `README.md` is the human-facing setup guide. When this file disagrees with prose elsewhere, re-open the cited source and trust the code.
+
+## What this is
+
+`GameplayFramework` is an **Unreal Engine 5.7** C++ plugin for building fully replicated, **data-driven Gameplay Ability System (GAS)** games. Almost everything is wired up through GameplayTags, Data Assets, and Data Tables; core classes are meant to be subclassed in C++ or Blueprints. Prefix conventions: `Da` (GameplayFramework module), `CE` (Collectibles module); `U`=UObject/component, `A`=Actor, `F`=struct, `I`=interface.
+
+## Critical: this is a SHARED plugin (symlink, not a submodule)
+
+- This plugin is its **own git repo** (`AyaDogGames/ModularGameplayFramework`), checked out at `C:/Source/GameplayFramework`.
+- Consumer projects (GlitchShaper, CollectorsEdition, Glitchwalker) do **not** vendor or submodule it. Their `setup.sh` creates `Plugins/GameplayFramework` as a **symlink/junction** to this one shared checkout. Each consumer `.gitignore`s that path and ships an empty `.gitmodules`.
+- **Editing any file under a consumer's `Plugins/GameplayFramework` edits this one shared repo and affects every consumer.** Always commit plugin changes from `C:/Source/GameplayFramework` directly — never through a consumer's `Plugins/GameplayFramework` path.
+
+## Modules (both Runtime — there is NO editor module)
+
+From `GameplayFramework.uplugin`:
+
+- **`GameplayFramework`** — `Type: Runtime`, `LoadingPhase: Default`. The main module. Startup (`Private/GameplayFramework.cpp`) just declares the `DA_GameplayFramework` log category and logs a load message — **no asset-type or factory registration**.
+- **`Collectibles`** — `Type: Runtime`, `LoadingPhase: PostDefault`. Depends on the `GameplayFramework` module. Startup logs "Collectibles submodule Loaded." (a verbatim UE-*module* log string — not a git submodule).
+
+There is **NO `GameplayFrameworkEditor` module** and no editor target of any kind. `GameplayFrameworkEditorToolingPlan.md` is an **aspirational design proposal**; its `UDaProjectSetupWizard` / `EGameType` / factories exist only in that markdown, not in code.
+
+### Plugin dependencies (`.uplugin`)
+`GameplayAbilities`, `EnhancedInput`, `CommonUI`, `ModelViewViewModel` (all enabled).
+
+### Build dependencies
+- `GameplayFramework.Build.cs` — Public: `Core`, `CoreUObject`, `Engine`, `InputCore`, `GameplayAbilities`, `EnhancedInput`, `GameplayTasks`, `DeveloperSettings`, `GameplayTags`, `AIModule`, `CommonUI`, `CommonInput`, `ModelViewViewModel`. Private: `Slate`, `SlateCore`, `UMG`, `Niagara`, `NavigationSystem`, `NetCore`.
+- `Collectibles.Build.cs` — Public: `Core`, `GameplayFramework`. Private: `CoreUObject`, `Engine`, `Slate`, `SlateCore`, `GameplayAbilities`, `GameplayTags`, `CommonUI`, `UMG`, `ModelViewViewModel`.
+
+## Source map (`Source/`)
+
+`Public/` holds headers; `Private/` mirrors it with implementations.
+
+- **`AbilitySystem/`** — `UDaAbilitySystemComponent`, `UDaAbilitySystemLibrary`, `UDaAbilitySet : UPrimaryDataAsset`. `Abilities/`: `UDaGameplayAbilityBase`, `UDaGameplayAbility_BaseTriggeredInputAction`, `UDaGameplayAbility_Death`, `UDaGameplayAbility_Projectile`, and the look/move input abilities `UUDaGameplayAbility_LookAction` / `UUDaGameplayAbility_MoveAction` (the literal **double-`U`** prefix is real — in both type name and filename; do not "fix" it). `Effects/`: `UDaGameplayEffect_DealDamage`, `UDaGameplayEffect_HealToMax`. `Modifiers/`: `UDaMMC_Health`. `Tasks/`: `UDaAbilityTask_TargetDataUnderCursor`.
+- **`AbilitySystem/Attributes/`** — `UDaBaseAttributeSet` (carries a `SetIdentifierTag`; subclasses map tags->attributes via `TagsToAttributes` in their constructor); `UDaCharacterAttributeSet` (Health/Mana), `UDaCombatAttributeSet` (damage/healing meta), `UDaDynamicAttributeSet`; `UDaExecution_HealWithMana`; data assets `UDaAttributeInfo`, `UDaAttributeSetDataAsset`.
+- **`AI/`** — `ADaAICharacter : ADaCharacterBase`; `ADAAICharacter_NPC : ACharacter, IAbilitySystemInterface` (dialog NPC, **not** a `ADaCharacterBase`); `ADaAIController`; BT services `UDaBTService_CheckAttackRange`, `UDaBTService_CheckLowHealth`; BT tasks `UDaBTTask_DoAbilityToSelf`, `UDaBTTask_DoAbilityToTargetActor`; `UDaNPCDialogData`.
+- **`Inventory/`** — the **new `FFastArraySerializer` system** (five files in each of Public/Private): `UDaInventoryComponent` (server-authoritative; replicates a `FDaInventoryList`, `MaxSlots=20`, `InventoryTags`; `AddItem`/`RemoveItem`/`MoveItem`/`Save`/`Load`, static `GetInventoryFromActor`; `OnEntryAdded`/`Removed`/`Changed` delegates; `Server_AddItem`/`RemoveItem`/`MoveItem` RPCs + `Internal_AddItem`), `UDaMasterInventory` (empty Blueprintable subclass), `FDaInventoryEntry : FFastArraySerializerItem`, `FDaInventoryList : FFastArraySerializer`, `UDaItemDefinition : UPrimaryDataAsset` (`GetPrimaryAssetId()` -> type `"ItemDefinition"`), `IDaInventoryItemInterface` (`GetItemDefinitionID`/`GetStackCount`/`AddToInventory`). The old UObject-based inventory (item base classes, factory, equipment component, blueprint library, UI widget/controller) was **deleted** — do not document it.
+- **`UI/`** — CommonUI + MVVM. Widget controllers `UDaWidgetController` -> `UDaOverlayWidgetController` -> `UDaOverlayWidgetController_Vitals`, plus `UDaStatMenuWidgetController`. CommonUI widgets `UDaActivatableWidget`, `UDaUserWidgetBase`, `UDaOverlayWidgetBase`, `UDaGameMenuBase`, `UDaPanelWidget`, `UDaPrimaryGameLayout`, `UDaTaggedWidget`. UUserWidget-based `UDaWorldUserWidget`, `UDaDamageWidget`, `UDaMessageWidget`. `ADaHUD`, `UDaCommonUIExtensions`; data assets `UDaUILevelData`, `UDaWidgetMessageData`. The only `UMVVMViewModelBase` in the plugin is the Collectibles `UCECollectibleViewModel` — there is **no** inventory ViewModel.
+- **Characters / game framework (`Public/` root)** — `ADaCharacterBase` (+ `IDaCharacterInterface`), `ADaCharacter`, `ADaPlayerCharacter_ThirdPerson`; `ADaPlayerState` (defines `FPlayerCharacterInfoRow : FTableRowBase`), `ADaPlayerController`, `ADaPlayerController_TopDown`; `ADaGameModeBase`, `ADaGameStateBase`, `UDaGameInstanceBase`; `UDaPawnData`; `UDaAttributeComponent` (vitals/Death); `UDaCommonGameViewportClient`.
+- **Input** — `UDaInputComponent : UEnhancedInputComponent` (set as the project's Default Input Component Class); `UDaInputConfig : UDataAsset` (Input tag -> InputAction map).
+- **Interaction / inspection** — `IDaInteractableInterface` + `UDaInteractionComponent`; `IDaInspectableInterface` + `UDaInspectableComponent` + `ADaInspectableItem`.
+- **Save** — `UDaSaveGame : USaveGame`, `UDaSaveGameSubsystem : UGameInstanceSubsystem`, `UDaSaveGameSettings : UDeveloperSettings`, `IDaSaveInterface`.
+- **Spawning** — `UDaActorSpawnManager` (base) with `UDaAISpawnManager` and `UDaPickupItemSpawnManager` (data-asset-driven, server, activated via game mode).
+- **Quest / state / checkpoint** — `UDaQuestComponent`, `UDaQuest`/`UDaQuestWithResult`, `FQuestInProgress`; state machine `UDaState`/`UDaBranch`/`UDaInputAtom`, `FStateMachineResult`; `ADaCheckpoint : APlayerStart`.
+- **Items / pickups / projectiles** — `ADaItemActor` (implements `IDaInteractableInterface`, `IAbilitySystemInterface`, `IDaInventoryItemInterface`), `ADaItemChest`, `ADaEffectActor`; `ADaPickupItem`, `ADaPickup_Ability`; `ADaProjectile`, `ADaProjectile_Magic`, `ADaTeleportProjectile`; `UDaRenderUtilLibrary`.
+- **Collectibles module (`Source/Collectibles/`, prefix `CE`)** — `ACECollectibleActorBase` (bridges into inventory via `IDaInventoryItemInterface`), `UCECollectibleData`, `ICECollectibleItemInterface`, `UCECollectibleProxy`, `ACECollectibleSpawnLocation`, `UCECollectibleViewModel : UMVVMViewModelBase`, `UCEItemCoinAttributeSet : UDaBaseAttributeSet`, `UDaAppraisalWidget : UDaPanelWidget`, plus `DataObjects/` (`UCEEditionTemplateData`, `UCEWearTemplateData`).
+
+## Gameplay tags (native)
+
+Declared with `DA_DECLARE_GAMEPLAY_TAG_EXTERN` / `CE_DECLARE_GAMEPLAY_TAG_EXTERN` and defined with `UE_DEFINE_GAMEPLAY_TAG[_COMMENT]`.
+
+- **Core** (`CoreGameplayTags.{h,cpp}`, namespace `CoreGameplayTags`): roots include `Input`, `Character`, `AbilitySet`, `Attributes`, `Inventory`, `InventoryItem`, `Message`, `UI`, `Status`, `Action`, `Pickup`, `Level`, `Ability`, `Event`, `Gameplay`, `Cheat`.
+- **Collectibles** (`CollectiblesGameplayTags.{h,cpp}`, namespace `CollectiblesGameplayTags`): `Collectibles.*` plus extensions of the core trees (`Inventory.Type.Collectibles`, `Attributes.Stats.Collectible*`).
+
+## Conventions
+
+- **Data-driven GAS.** New attributes: subclass `UDaBaseAttributeSet`, set a parent `SetIdentifierTag`, and register attributes in the constructor via `TagsToAttributes.Add(Tag, GetXAttribute)`. `Attributes.Stats.Primary` are set directly; `.Secondary` are derived via gameplay effects.
+- **Tag-driven UI (MVC/MVVM).** AttributeSet (model) -> WidgetController (listens/broadcasts) -> UserWidget (view), wired by gameplay tag. Built on CommonUI + ModelViewViewModel.
+- **Replication.** Inventory and attributes are server-authoritative; inventory uses `FFastArraySerializer` delta replication. Mutate inventory via the component's BlueprintCallable API (which routes through `Server_*` RPCs), not by editing entries directly.
+- **Asset Manager.** `UDaItemDefinition::GetPrimaryAssetId()` returns the `"ItemDefinition"` type, but the plugin does **not** register it at startup and ships no `Config/`. Consumers must add `ItemDefinition` (and any other primary data-asset types they use) to `PrimaryAssetTypesToScan` in their own `DefaultGame.ini`.
+
+## Build / run
+
+1. The plugin compiles as part of a consuming UE 5.7 project — there is no standalone build.
+2. Run the project's **GenerateProjectFiles** so both modules are detected, then build the `.sln` (Windows) / project from your IDE or the editor.
+3. Engine reference for API checks: `C:/Source/UnrealEngine` (UE 5.7.4, release).
+
+## No automated tests
+
+There is no test module, test target, or CI test runner in this repository. Do not claim or invent one.
+
+## Pointers
+
+- `README.md` — human setup guide.
+- `GameplayFrameworkEditorToolingPlan.md` — **aspirational** editor-tooling proposal (not implemented).
+- `specs/2026-03-11-inventory-refactor.md` — the FastArray inventory plan. The shipped code (above) is authoritative where it differs (e.g. RPC names are `Server_AddItem`/`RemoveItem`/`MoveItem`; there is no `Server_RequestStackItems`, no `IDaInventoryChangeListener`, no `UDaInventoryViewModel`).

--- a/GameplayFrameworkEditorToolingPlan.md
+++ b/GameplayFrameworkEditorToolingPlan.md
@@ -1,3 +1,12 @@
+> # ⚠️ STATUS: ASPIRATIONAL — NOT IMPLEMENTED
+> This document is a **design proposal**, not a description of shipped functionality.
+> **None of it exists in code.** There is **no `GameplayFrameworkEditor` module** (the plugin
+> declares only two Runtime modules, `GameplayFramework` and `Collectibles`, in
+> `GameplayFramework.uplugin`), and none of the classes named below
+> (`UDaProjectSetupWizard`, `EGameType`, `UDaCoreClassFactory`, the various wizards/factories/
+> validators, etc.) are present anywhere under `Source/`. Treat everything here as a future
+> wish-list for UE 5.7 editor tooling — do not cite it as an existing API.
+
 # GameplayFramework Editor Tooling Plan
 
 Based on analysis of the plugin structure and setup requirements, this document outlines a comprehensive editor tooling plan to automate game creation using the GameplayFramework plugin.

--- a/README.md
+++ b/README.md
@@ -1,65 +1,83 @@
 # GameplayFramework
 
-The gameplay framework is an Unreal 5.5 C++ plugin that simplifies creating a fully replicated data-driven Gameplay Ability System (GAS) based game rapidly. Classes can be overriden in C++ or Blueprints but often will expect Data Tables or Data Assets to set them up.
+The gameplay framework is an Unreal Engine 5.7 C++ plugin that simplifies creating a fully replicated data-driven Gameplay Ability System (GAS) based game rapidly. Classes can be overridden in C++ or Blueprints but often will expect Data Tables or Data Assets to set them up.
+
+> Agents: see `CLAUDE.md` for the canonical contributor/agent guide (module map, conventions, the shared-symlink gotcha, build steps). This README is the human-facing setup guide.
 
 ## Overview
 
-The plugin utilizes the Gameplay Ability System (GAS) and while originally influenced by the Epic Games Lyra example; it is different. It combines several concepts such as data driven ability set creation and provides an optional attribute component that is responsible for handling vital attributes like Health and Death of an actor, but any attributes can be created in game as long as they are vended using the parent gameplay tags provided in the plugin. For example, One could use the Attributes.Stats.Primary and the Attributes.Stat.Secondary and subclass DaBaseAttributeSet to create a set of Attributes for their specific game. The base class would need a parent SetIdentifierTag (in this case Attributes.Stats), and would nee dto asssociate all Attributes with gameplay tags in the constructor like so: TagsToAttributes.Add(YourGameplayTags::AttributesStatsPrimaryStrength, GetStrengthAttribute);
+The plugin utilizes the Gameplay Ability System (GAS) and while originally influenced by the Epic Games Lyra example; it is different. It combines several concepts such as data driven ability set creation and provides an optional attribute component that is responsible for handling vital attributes like Health and Death of an actor, but any attributes can be created in game as long as they are vended using the parent gameplay tags provided in the plugin. For example, one could use `Attributes.Stats.Primary` and `Attributes.Stats.Secondary` and subclass `DaBaseAttributeSet` to create a set of Attributes for their specific game. The base class would need a parent `SetIdentifierTag` (in this case `Attributes.Stats`), and would need to associate all Attributes with gameplay tags in the constructor like so: `TagsToAttributes.Add(YourGameplayTags::AttributesStatsPrimaryStrength, GetStrengthAttribute);`
 
-UI Base classes that handle and vend attribute updates are also provided. A WidgetController subclass will be associcated with attribute set tag and look for all attributes in the set and provide updates whenever their values change using multicast delegate methods. 
+UI Base classes that handle and vend attribute updates are also provided. A `WidgetController` subclass is associated with an attribute set tag and looks for all attributes in the set and provides updates whenever their values change using multicast delegate methods.
 
-An inventory Component and Inventory Item class can be used to create an inventory system and attache dto any actor. Inventory Item subclasses should be created using the factory to associate inventory items with actor types. 
+It provides core base character classes and player state set up with an ability system component and an attribute component, and subclasses for players and NPCs. Characters are granted attribute sets, gameplay effects, and gameplay abilities set up with AbilitySets defined as DataAssets.
 
-It provides core base character classes and player state set up with an ability system component and an attribute component, and subclasses for players and NPCs. Characters are granted attribute sets, gameplay effects, and gameplay abilities set up with AbilitySets defined as DataAssets. 
+For player stats or attributes (strength, intelligence, armor, etc), define a subclass of `DaBaseAttributeSet`, define each attribute using the parent GameplayTag `Attributes.Stats`, and set up event handlers in blueprints. `Attributes.Stats.Primary` are meant to be set directly while those with `Attributes.Stats.Secondary` are derived from Primary (through a gameplay effect).
 
-For player stats or attributes (strength, intelligence, armor, etc), define a subclass of DaAttributeSet, define each attribute using the parent GameplayTag: Attributes.Stat, and setup event handlers in blueprints. Attributes.Stat.Primary are meant to be set directly while those with Attributes.Stat.Secondary are derived from Primary (through a gameplay effect).
+The UI is based on an event-driven MVC/MVVM design pattern with AttributeSet subclasses (model), WidgetControllers listening and broadcasting changes to UserWidgets (controller->view), all driven via GameplayTags. UI is built on **CommonUI** and the **ModelViewViewModel** plugin.
 
-The UI is based on an event driven MVC design pattern with AttributeSet subclasses (model), WidgetControllers listening and broadcasting changes to UserWidgets (controller->view), all driven via GameplayTags. 
+The game using this plugin is responsible for creating its own `DaBaseAttributeSet` subclass for things like Stats and a `DaAttributeInfo` DataAsset to define associated UI (images and text for each widget type) and connects attributes to widgets via their gameplay tag.
 
-The game using this plugin is responsible for creating its own DaAttributeSet subclass for things like Stats and DaAttributeInfo DataAsset to define things associated (like its widgets), defines images and text for each widget type (like for buttons: borders, button background images and text) and connects attributes to widgets via its gameplay tag.  
+Some Gameplay effects are required by default (and are available in the plugin's content folder) as they are responsible for important things like handling death or setting an attribute set's default values.
 
-Some Gameplay effects are required by default (and are available in the plugin's content folder) as they are responsible for important things like handling death or setting an attribute set's default values. 
+There is a GAS-based projectile system, an item pickup system to create abilities on the fly, and a data-driven Enhanced Input system that can be set up using GAS abilities or directly in a player character or controller.
 
-There is a GAS based projectile system, an item pickup system to create abilities on the fly, a data driven enhanced input system that can either be set up using GAS abilities or directly in a player character or controller.
+Replicated Actors can be continuously spawned on the server via the game mode by setting a Spawner subclass in its blueprint, which spawns actors defined via data asset. There is an item spawner (`UDaPickupItemSpawnManager`) and an AI character spawner (`UDaAISpawnManager`), both subclasses of `UDaActorSpawnManager`, which can be activated via the game mode.
 
-Replicated Actors can be continuously spawned on the server via game mode by setting a Spawner subclass in its blueprint which will spawn actors defined via data asset. Currently there is an Item spawner and an AI Character spawner which can be activated via game mode.
+The AI characters can run around, find a `TargetActor` using pawn sensing and try to attack it (via gameplay ability), and run away and heal (via gameplay ability) if damaged.
 
-The AICharacters predefined in the engine can run around, find a TargetActor using pawn sensing and try to attack it (via gameplay ability), and run away and heal (via gameplay ability) if damaged. 
+### Inventory (FFastArraySerializer)
+
+Inventory is a replicated, server-authoritative system built on Unreal's `FFastArraySerializer` for efficient delta replication:
+
+- `UDaInventoryComponent : UActorComponent` — attach to any actor. Server-authoritative, replicates a `FDaInventoryList`, a `MaxSlots` (default 20), and `InventoryTags`. BlueprintCallable API includes `AddItem(FPrimaryAssetId, StackCount=1, SlotHint=-1)`, `RemoveItem(SlotIndex, Count=0)`, `MoveItem(From, To)`, `GetAllEntries`, `GetEntryAtSlot`, `SaveInventory`/`LoadInventory`, and the static `GetInventoryFromActor`. It broadcasts `OnEntryAdded` / `OnEntryRemoved` / `OnEntryChanged` delegates for decoupled UI. `UDaMasterInventory` is a Blueprintable subclass variant.
+- `FDaInventoryEntry : FFastArraySerializerItem` — the replicated per-item instance (`ItemID`, `ItemDefinitionID`, `SlotIndex`, `StackCount`, `MaxStackCount`, `Tags`, `AbilitySetID`); auto-stacks when `MaxStackCount > 1`.
+- `UDaItemDefinition : UPrimaryDataAsset` — designer-authored item template (display name/description, icon, mesh, tags, max stack count, an `AbilitySet` to grant, equip-slot tags). Its `GetPrimaryAssetId()` returns the `"ItemDefinition"` primary asset type.
+- `IDaInventoryItemInterface` — implement on world actors to make them addable to an inventory; exposes `GetItemDefinitionID()`, `GetStackCount()`, and `AddToInventory(InstigatorPawn, bDestroyActor)`. Implemented by `ADaItemActor` and the Collectibles `ACECollectibleActorBase` / `UCECollectibleProxy`.
+
+Because item definitions resolve via the Asset Manager, consumers must add `ItemDefinition` to `PrimaryAssetTypesToScan` in their project's `DefaultGame.ini` (the plugin ships no `Config/`). See **Setup** step 10.
 
 ## Setup
 
-1. Create an Unreal C++ project and either clone the plugin to Project Folder/Plugins/GameplayFramework as a [git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules) or download the zip and place in an Unreal Plugin folder.
-2. Enable the Plugin in the project editor Plugins, or in C++, add "GameplayFramework" to the list of required public submodules in your project's Build.cs file. 
-3. Create subclasses in either C++ or Blueprints for the core classes: DaGameStateBase, DaGameModeBase, DaCharacter, DaPlayerState, DaPlayerController, DaHud.
-4. Set your Game mode subclass up to use those and set it as the map's game mode or default game mode in settings.
-5. Create a DaAbilitySet Data Asset where you can assign GameplayAbilities to Input Tags, setup any non-default Attribute Sets (DaPlayerState and DaAICharacter both creates a default Character set for Health and Mana and a combat set to handle damage and healing), GameplayEffects. Create a DaPlayerPawn Data Asset and set the AbilitySet you previously created and then make a DataTable of PlayerInfoRow and set the PlayerPawnDataAsset here.
+1. Clone the plugin to its own location (e.g. `C:/Source/GameplayFramework`). This plugin is its **own git repository** (`AyaDogGames/ModularGameplayFramework`). In the consumer projects in this workspace it is **not** added as a git submodule — instead each consumer's `setup.sh` creates `Plugins/GameplayFramework` as a **symlink/junction** to the one shared checkout (see **Shared plugin (symlink) model** below). For a standalone project you may instead copy/clone the plugin directly into `YourProject/Plugins/GameplayFramework`.
+2. Enable the plugin in the project editor Plugins panel, or in C++ add `"GameplayFramework"` (and `"Collectibles"` if needed) to the public/private dependency module names in your project's `Build.cs`.
+3. Create subclasses in either C++ or Blueprints for the core classes: `DaGameStateBase`, `DaGameModeBase`, `DaCharacter` (or `DaPlayerCharacter_ThirdPerson`), `DaPlayerState`, `DaPlayerController`, `DaHUD`.
+4. Set your game mode subclass to use those, and set it as the map's game mode or default game mode in settings.
+5. Create a `DaAbilitySet` Data Asset where you assign GameplayAbilities to Input Tags, set up any non-default Attribute Sets (`DaPlayerState` and the AI character both create a default Character set for Health and Mana and a combat set to handle damage and healing), and GameplayEffects. Create a `DaPawnData` Data Asset, set the AbilitySet you created on it, then make a DataTable of `FPlayerCharacterInfoRow` and set the pawn data asset there.
 6. Set the DataTable on the PlayerState as well as a GameplayEffect to reset Health. There is one pre-made in the plugin's Content folder that can be used for this.
-7. In Project settings->Input Set the Default Input Component Class to DaInputComponent.
-8. Create your EnhancedInput InputActions and Mapping Contexts then create a DaInputConfig DataAsset and map InputTags to InputComponents as needed. Provide this file to your DaPlayerController subclass to dynamcially connect Input to GameplayAbilities previously defined in the character ability set.
-9. HUD: Create an OverlayWidgetController and Overlay UserWidget class and set them on the HUD's properties. 
-10. In project Settings->Game->Asset Manager: Create 3 new entries in the Primary Data Types to Scan array:
-    1. PrimaryAssetType: MinionPawnData, AssetBaseClass: DaMinionPawnData, directory where these data assets can be found. Set rules to always cook. (If not using DaAICharacter for AI this can be skipped).
-    2. PrimaryAssetType: AbilitySetData, AssetBaseClass: DaAbilitySet, directory where these data assets can be found. Set rules to always cook.
-    3. PrimaryAssetType: PlayerPawnData, AssetBaseClass: DaPlayerPawnData, directory where these data assets can be found. Set rules to always cook.
-11. Developer tab can change SaveGame name.
+7. In Project Settings -> Input, set the Default Input Component Class to `DaInputComponent`.
+8. Create your Enhanced Input InputActions and Mapping Contexts, then create a `DaInputConfig` DataAsset and map InputTags to InputActions as needed. Provide this asset to your `DaPlayerController` subclass to dynamically connect input to GameplayAbilities defined in the character ability set.
+9. HUD: Create an OverlayWidgetController and Overlay UserWidget class and set them on the HUD's properties.
+10. In Project Settings -> Game -> Asset Manager, add entries to the **Primary Asset Types to Scan** array for the data-asset types your game uses. The plugin defines exactly one primary asset type string in code: `ItemDefinition` (via `UDaItemDefinition::GetPrimaryAssetId()`). If you use the inventory system you must add:
+    - PrimaryAssetType: `ItemDefinition`, AssetBaseClass: `DaItemDefinition`, the directory where these data assets live, rules set to always cook.
+
+    For the other plugin DataAsset classes you load through the Asset Manager (e.g. `DaAbilitySet`, `DaPawnData`, AI pawn data) add similar entries (AssetBaseClass + scan directory, always cook). The PrimaryAssetType *name* for those is whatever you choose in your project config — the plugin does not register or mandate one.
+11. The Developer Settings tab (`DaSaveGameSettings`) can change the SaveGame slot name.
+
+## Shared plugin (symlink) model
+
+Within this workspace the plugin is shared by multiple consumer projects via a symlink rather than a copy or a submodule:
+
+- The plugin lives in its own repo at `C:/Source/GameplayFramework` (`AyaDogGames/ModularGameplayFramework`).
+- Each consumer's `setup.sh` runs `ln -s "$SHARED_GAMEPLAY_FRAMEWORK" "$REPO/Plugins/GameplayFramework"` (default source `/c/Source/GameplayFramework`, overridable via the `SHARED_GAMEPLAY_FRAMEWORK` env var). On Windows this is a directory symlink/junction.
+- **Editing the plugin from any consumer's `Plugins/GameplayFramework` path edits the one shared repo and affects every consumer.** Always commit plugin changes from `C:/Source/GameplayFramework` directly.
+- Consumer repos `.gitignore` the `Plugins/GameplayFramework` path (and ship an empty `.gitmodules`), so the plugin is an untracked symlinked checkout there — **not** a git submodule.
 
 ## Building the Plugin
 
-After adding the plugin to your Unreal Engine 5.5 project:
+After adding the plugin to your Unreal Engine 5.7 project:
 
-1. Run Unreal's **GenerateProjectFiles** script for your project so the module is detected by your IDE.
-2. Open the generated project files (for example the `.sln` on Windows) and build the project. The GameplayFramework module will compile with the rest of your project.
+1. Run Unreal's **GenerateProjectFiles** script for your project so the modules are detected by your IDE.
+2. Open the generated project files (for example the `.sln` on Windows) and build the project. The `GameplayFramework` and `Collectibles` modules compile with the rest of your project.
 
 The repository does not contain automated tests.
 
 ## Configuration
 
-There are lots of ways to configure the project. UI, AI, Camera modes, various gameplay abilities, effects, etc. 
-TODO: More on this...
+There are many ways to configure a project built on the framework: UI, AI, camera modes, gameplay abilities, effects, attribute sets, inventory, etc. Most configuration is driven through Data Assets and Data Tables wired up by gameplay tags, plus the Asset Manager entries from **Setup** step 10. The Developer Settings tab exposes save-game options.
 
-## Debug 
+## Debug
 
-### CVARS
-Using da. in UE's editor console will show lots of useful CVars available for debugging.
-TODO: More on this....
+### CVars
 
+Typing `da.` in UE's editor console reveals the framework's debug CVars (toggles and visualizers exposed by the plugin's subsystems).


### PR DESCRIPTION
## What
Sync the GameplayFramework plugin's docs to the actual code and add a canonical agent guide.

- **README.md** — engine corrected to **UE 5.7** (was 5.5); the "git submodule" install replaced with the accurate **shared symlink** model (`setup.sh` links `Plugins/GameplayFramework` to the shared checkout, gitignored in consumers, not a submodule); Inventory section rewritten to the new **`FFastArraySerializer`** API (`UDaInventoryComponent`, `FDaInventoryEntry`, `FDaInventoryList`, `UDaItemDefinition`, `IDaInventoryItemInterface`); renamed classes corrected in setup steps; Asset Manager step clarified (`ItemDefinition` is the one code-defined primary asset type); stale TODOs resolved.
- **CLAUDE.md** (new) — canonical agent/contributor guide: overview, UE 5.7, the two Runtime modules (`GameplayFramework` Default + `Collectibles` PostDefault) and **no editor module**, plugin/build deps, a Public/Private source map of every subsystem, conventions (Da prefix, tag-driven data-driven GAS), the **shared-symlink gotcha**, GenerateProjectFiles/build, "no automated tests", and pointers.
- **AGENTS.md** — reduced to a short pointer to CLAUDE.md (canonical) + README.md; no duplicated content.
- **GameplayFrameworkEditorToolingPlan.md** — prepended an unambiguous **ASPIRATIONAL / NOT-IMPLEMENTED** status banner (there is no `GameplayFrameworkEditor` module; the wizard/factory classes exist only in that markdown).

## Why
The shipped docs claimed UE 5.5, a git-submodule install, and the old (deleted) UObject inventory. Every factual claim here was verified against the source on disk (`.uplugin`, both `Build.cs`, the `Source/` headers) and adversarially self-reviewed across three lenses (code-accuracy, completeness, agent-effectiveness).

Generated by `drive-docs-sync` (UE 5.7 docs/agent-guide sync).